### PR TITLE
fix: Use /bin/env to search for commands

### DIFF
--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -10230,7 +10230,10 @@ const core = __importStar(__nccwpck_require__(2186));
  */
 function fileExistsInS3({ key, bucket }) {
     return __awaiter(this, void 0, void 0, function* () {
-        return execIsSuccessful('aws s3api head-object', [`--bucket=${bucket}`, `--key=${key}`]);
+        return execIsSuccessful('/usr/bin/env aws s3api head-object', [
+            `--bucket=${bucket}`,
+            `--key=${key}`
+        ]);
     });
 }
 exports.fileExistsInS3 = fileExistsInS3;
@@ -10261,7 +10264,7 @@ function execIsSuccessful(commandLine, args) {
  */
 function writeLineToFile({ text, path }) {
     return __awaiter(this, void 0, void 0, function* () {
-        yield (0, exec_1.exec)(`/bin/bash -c "echo ${text} > ${path}"`);
+        yield (0, exec_1.exec)(`/usr/bin/env bash -c "echo ${text} > ${path}"`);
     });
 }
 exports.writeLineToFile = writeLineToFile;
@@ -10275,7 +10278,7 @@ exports.writeLineToFile = writeLineToFile;
  */
 function copyFileToS3({ path, key, bucket }) {
     return __awaiter(this, void 0, void 0, function* () {
-        yield (0, exec_1.exec)('aws s3 cp', [path, `s3://${bucket}/${key}`]);
+        yield (0, exec_1.exec)('/usr/bin/env aws s3 cp', [path, `s3://${bucket}/${key}`]);
     });
 }
 exports.copyFileToS3 = copyFileToS3;
@@ -10308,7 +10311,7 @@ exports.runAction = runAction;
  */
 function getTreeHashForCommitHash(commit) {
     return __awaiter(this, void 0, void 0, function* () {
-        return execReadOutput('git rev-parse', [`${commit}:`]);
+        return execReadOutput('/usr/bin/env git rev-parse', [`${commit}:`]);
     });
 }
 exports.getTreeHashForCommitHash = getTreeHashForCommitHash;

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -3408,7 +3408,10 @@ const core = __importStar(__nccwpck_require__(186));
  */
 function fileExistsInS3({ key, bucket }) {
     return __awaiter(this, void 0, void 0, function* () {
-        return execIsSuccessful('aws s3api head-object', [`--bucket=${bucket}`, `--key=${key}`]);
+        return execIsSuccessful('/usr/bin/env aws s3api head-object', [
+            `--bucket=${bucket}`,
+            `--key=${key}`
+        ]);
     });
 }
 exports.fileExistsInS3 = fileExistsInS3;
@@ -3439,7 +3442,7 @@ function execIsSuccessful(commandLine, args) {
  */
 function writeLineToFile({ text, path }) {
     return __awaiter(this, void 0, void 0, function* () {
-        yield (0, exec_1.exec)(`/bin/bash -c "echo ${text} > ${path}"`);
+        yield (0, exec_1.exec)(`/usr/bin/env bash -c "echo ${text} > ${path}"`);
     });
 }
 exports.writeLineToFile = writeLineToFile;
@@ -3453,7 +3456,7 @@ exports.writeLineToFile = writeLineToFile;
  */
 function copyFileToS3({ path, key, bucket }) {
     return __awaiter(this, void 0, void 0, function* () {
-        yield (0, exec_1.exec)('aws s3 cp', [path, `s3://${bucket}/${key}`]);
+        yield (0, exec_1.exec)('/usr/bin/env aws s3 cp', [path, `s3://${bucket}/${key}`]);
     });
 }
 exports.copyFileToS3 = copyFileToS3;
@@ -3486,7 +3489,7 @@ exports.runAction = runAction;
  */
 function getTreeHashForCommitHash(commit) {
     return __awaiter(this, void 0, void 0, function* () {
-        return execReadOutput('git rev-parse', [`${commit}:`]);
+        return execReadOutput('/usr/bin/env git rev-parse', [`${commit}:`]);
     });
 }
 exports.getTreeHashForCommitHash = getTreeHashForCommitHash;

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,6 +1,5 @@
 import * as utils from './utils'
 import {exec} from '@actions/exec'
-import * as core from '@actions/core'
 
 jest.mock('@actions/core')
 jest.mock('@actions/exec')

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -17,7 +17,7 @@ describe(`Actions Utils`, () => {
         const hash = '5265ef99f1c8e18bcd282a11a4b752731cad5665'
         const output = await utils.getTreeHashForCommitHash(hash)
         expect(mockedExec).toHaveBeenCalledWith(
-            'git rev-parse',
+            '/usr/bin/env git rev-parse',
             ['5265ef99f1c8e18bcd282a11a4b752731cad5665:'],
             {
                 listeners: {stdout: expect.any(Function)}
@@ -29,7 +29,7 @@ describe(`Actions Utils`, () => {
     test(`getCurrentRepoTreeHash uses git CLI to return the latest tree hash of the root of the repo`, async () => {
         mockedExec.mockResolvedValue(0)
         const output = await utils.getCurrentRepoTreeHash()
-        expect(mockedExec).toHaveBeenCalledWith('git rev-parse', ['HEAD:'], {
+        expect(mockedExec).toHaveBeenCalledWith('/usr/bin/env git rev-parse', ['HEAD:'], {
             listeners: {stdout: expect.any(Function)}
         })
         expect(output).toBe('')
@@ -38,14 +38,16 @@ describe(`Actions Utils`, () => {
     test(`writeLineToFile creates a file using a shell script`, async () => {
         mockedExec.mockResolvedValue(0)
         await utils.writeLineToFile({path: '/some/file', text: 'hello world'})
-        expect(mockedExec).toHaveBeenCalledWith(`/bin/bash -c "echo hello world > /some/file"`)
+        expect(mockedExec).toHaveBeenCalledWith(
+            `/usr/bin/env bash -c "echo hello world > /some/file"`
+        )
     })
 
     describe('S3 Utils', () => {
         test(`fileExistsInS3 uses AWS CLI to check for of an object in S3 bucket, returns true if it exists`, async () => {
             mockedExec.mockResolvedValue(0)
             const output = await utils.fileExistsInS3({key: 'my/key', bucket: 'my-bucket'})
-            expect(mockedExec).toHaveBeenCalledWith('aws s3api head-object', [
+            expect(mockedExec).toHaveBeenCalledWith('/usr/bin/env aws s3api head-object', [
                 '--bucket=my-bucket',
                 '--key=my/key'
             ])
@@ -55,7 +57,7 @@ describe(`Actions Utils`, () => {
         test(`fileExistsInS3 uses AWS CLI to check for of an object in S3 bucket, returns true if it exists`, async () => {
             mockedExec.mockRejectedValue(255)
             const output = await utils.fileExistsInS3({key: 'my/key', bucket: 'my-bucket'})
-            expect(mockedExec).toHaveBeenCalledWith('aws s3api head-object', [
+            expect(mockedExec).toHaveBeenCalledWith('/usr/bin/env aws s3api head-object', [
                 '--bucket=my-bucket',
                 '--key=my/key'
             ])
@@ -65,7 +67,7 @@ describe(`Actions Utils`, () => {
         test(`copyFileToS3 uses AWS CLI to copy a local file to S3 bucket`, async () => {
             mockedExec.mockResolvedValue(0)
             await utils.copyFileToS3({path: '/some/file', key: 'my/key', bucket: 'my-bucket'})
-            expect(mockedExec).toHaveBeenCalledWith('aws s3 cp', [
+            expect(mockedExec).toHaveBeenCalledWith('/usr/bin/env aws s3 cp', [
                 '/some/file',
                 's3://my-bucket/my/key'
             ])

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,7 +9,10 @@ import * as core from '@actions/core'
  * @returns fileExists - boolean indicating if the file exists
  */
 export async function fileExistsInS3({key, bucket}: {key: string; bucket: string}) {
-    return execIsSuccessful('aws s3api head-object', [`--bucket=${bucket}`, `--key=${key}`])
+    return execIsSuccessful('/usr/bin/env aws s3api head-object', [
+        `--bucket=${bucket}`,
+        `--key=${key}`
+    ])
 }
 
 /**
@@ -36,7 +39,7 @@ async function execIsSuccessful(commandLine: string, args?: string[]) {
  * @returns exitCode - shell command exit code
  */
 export async function writeLineToFile({text, path}: {text: string; path: string}) {
-    await exec(`/bin/bash -c "echo ${text} > ${path}"`)
+    await exec(`/usr/bin/env bash -c "echo ${text} > ${path}"`)
 }
 
 /**
@@ -56,7 +59,7 @@ export async function copyFileToS3({
     key: string
     bucket: string
 }) {
-    await exec('aws s3 cp', [path, `s3://${bucket}/${key}`])
+    await exec('/usr/bin/env aws s3 cp', [path, `s3://${bucket}/${key}`])
 }
 
 /**
@@ -82,7 +85,7 @@ export async function runAction(action: () => Promise<unknown>) {
  * @returns treeHash
  */
 export async function getTreeHashForCommitHash(commit: string) {
-    return execReadOutput('git rev-parse', [`${commit}:`])
+    return execReadOutput('/usr/bin/env git rev-parse', [`${commit}:`])
 }
 
 /**


### PR DESCRIPTION
This will make the execution utility functions more resilient to failures when running on different environments by utilizing `/bin/env` for finding commands in `$PATH`. 