### PR TITLE
feat: Use AWS input parameters for region and secrets in AWS CLI invocation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+dist/** linguist-generated

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## Description
 
-Allows to skip a job if it already succeeded for the same repo state. Uses S3 for caching.
+Allows to skip a job if it already succeeded for the same repo tree hash. Uses S3 for caching.
 
 <!-- action-docs-description -->
 
@@ -37,10 +37,13 @@ that's the case.
 
 ## Inputs
 
-| parameter   | description                                                                                                                                                                 | required | default           |
-| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------------- |
-| bucket_name | Name of the S3 bucket to use for storing cache files. The job needs to have AWS credentials configured to allow read/write from this bucket.                                | `true`   |                   |
-| key_prefix  | Key prefix to add to the cache files key. By default the job ID is used. The full key used for the cache files is "cache/${repoOwner}/${repoName}/${keyPrefix}/${treeHash}" | `false`  | ${{ github.job }} |
+| parameter             | description                                                                                                                                                                 | required | default                          |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | -------------------------------- |
+| bucket-name           | Name of the S3 bucket to use for storing cache files. The job needs to have AWS credentials configured to allow read/write from this bucket.                                | `true`   |                                  |
+| key-prefix            | Key prefix to add to the cache files key. By default the job ID is used. The full key used for the cache files is "cache/${repoOwner}/${repoName}/${keyPrefix}/${treeHash}" | `false`  | ${{ github.job }}                |
+| aws-region            | AWS region for the S3 bucket used for storing hashes.                                                                                                                       | `false`  | ${{ env.AWS_REGION }}            |
+| aws-access-key-id     | AWS Access Key for the AWS account managing the S3 bucket used for storing hashes.                                                                                          | `false`  | ${{ env.AWS_ACCESS_KEY_ID }}     |
+| aws-secret-access-key | AWS Secret Access Key for the AWS account managing the S3 bucket used for storing hashes.                                                                                   | `false`  | ${{ env.AWS_SECRET_ACCESS_KEY }} |
 
 <!-- action-docs-inputs -->
 
@@ -48,10 +51,10 @@ that's the case.
 
 ## Outputs
 
-| parameter | description                                                                    |
-| --------- | ------------------------------------------------------------------------------ |
-| processed | Indicates if the job has already been performed for the current repo tree hash |
-| hash      | The repo tree hash which was used for caching                                  |
+| parameter | description                                                                     |
+| --------- | ------------------------------------------------------------------------------- |
+| processed | Indicates if the job has already been performed for the current repo tree hash. |
+| hash      | The repo tree hash which was used for caching.                                  |
 
 <!-- action-docs-outputs -->
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ that's the case.
 | bucket-name           | Name of the S3 bucket to use for storing cache files. The job needs to have AWS credentials configured to allow read/write from this bucket.                                | `true`   |                                  |
 | key-prefix            | Key prefix to add to the cache files key. By default the job ID is used. The full key used for the cache files is `cache/${repoOwner}/${repoName}/${keyPrefix}/${treeHash}` | `false`  | ${{ github.job }}                |
 | aws-region            | AWS region for the S3 bucket used for storing hashes.                                                                                                                       | `false`  | ${{ env.AWS_REGION }}            |
-| aws-access-key-id     | AWS Access Key for the AWS account managing the S3 bucket used for storing hashes.                                                                                          | `false`  | ${{ env.AWS_ACCESS_KEY_ID }}     |
+| aws-access-key-id     | AWS Access Key for the AWS account managing the S3 bucket used for storing cache files.                                                                                     | `false`  | ${{ env.AWS_ACCESS_KEY_ID }}     |
 | aws-secret-access-key | AWS Secret Access Key for the AWS account managing the S3 bucket used for storing hashes.                                                                                   | `false`  | ${{ env.AWS_SECRET_ACCESS_KEY }} |
 
 <!-- action-docs-inputs -->

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 | <img width="500" alt="On the first run, the action reports no cache and the long task is done." src="https://user-images.githubusercontent.com/4643658/180269047-417226dd-ce8f-41a6-92ee-e6ed7d279cb6.png"> | <img width="500" alt="On the next run, the action reports cache hit, and the long task is skipped" src="https://user-images.githubusercontent.com/4643658/180269038-9f896490-619f-4fd8-b801-af01b62b1981.png"> |
 
 <!-- action-docs-description -->
-
 ## Description
 
 Allows to skip a job if it already succeeded for the same repo tree hash. Uses S3 for caching.
+
 
 <!-- action-docs-description -->
 
@@ -34,27 +34,29 @@ allow to read and write to the S3 bucket provided as input. Use the
 that's the case.
 
 <!-- action-docs-inputs -->
-
 ## Inputs
 
-| parameter             | description                                                                                                                                                                 | required | default                          |
-| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | -------------------------------- |
-| bucket-name           | Name of the S3 bucket to use for storing cache files. The job needs to have AWS credentials configured to allow read/write from this bucket.                                | `true`   |                                  |
-| key-prefix            | Key prefix to add to the cache files key. By default the job ID is used. The full key used for the cache files is "cache/${repoOwner}/${repoName}/${keyPrefix}/${treeHash}" | `false`  | ${{ github.job }}                |
-| aws-region            | AWS region for the S3 bucket used for storing hashes.                                                                                                                       | `false`  | ${{ env.AWS_REGION }}            |
-| aws-access-key-id     | AWS Access Key for the AWS account managing the S3 bucket used for storing hashes.                                                                                          | `false`  | ${{ env.AWS_ACCESS_KEY_ID }}     |
-| aws-secret-access-key | AWS Secret Access Key for the AWS account managing the S3 bucket used for storing hashes.                                                                                   | `false`  | ${{ env.AWS_SECRET_ACCESS_KEY }} |
+| parameter | description | required | default |
+| - | - | - | - |
+| bucket-name | Name of the S3 bucket to use for storing cache files. The job needs to have AWS credentials configured to allow read/write from this bucket. | `true` |  |
+| key-prefix | Key prefix to add to the cache files key. By default the job ID is used. The full key used for the cache files is `cache/${repoOwner}/${repoName}/${keyPrefix}/${treeHash}` | `false` | ${{ github.job }} |
+| aws-region | AWS region for the S3 bucket used for storing hashes. | `false` | ${{ env.AWS_REGION }} |
+| aws-access-key-id | AWS Access Key for the AWS account managing the S3 bucket used for storing hashes. | `false` | ${{ env.AWS_ACCESS_KEY_ID }} |
+| aws-secret-access-key | AWS Secret Access Key for the AWS account managing the S3 bucket used for storing hashes. | `false` | ${{ env.AWS_SECRET_ACCESS_KEY }} |
+
+
 
 <!-- action-docs-inputs -->
 
 <!-- action-docs-outputs -->
-
 ## Outputs
 
-| parameter | description                                                                     |
-| --------- | ------------------------------------------------------------------------------- |
+| parameter | description |
+| - | - |
 | processed | Indicates if the job has already been performed for the current repo tree hash. |
-| hash      | The repo tree hash which was used for caching.                                  |
+| hash | The repo tree hash which was used for caching. |
+
+
 
 <!-- action-docs-outputs -->
 
@@ -75,10 +77,10 @@ that's the case.
 ```
 
 <!-- action-docs-runs -->
-
 ## Runs
 
 This action is a `node16` action.
+
 
 <!-- action-docs-runs -->
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 | <img width="500" alt="On the first run, the action reports no cache and the long task is done." src="https://user-images.githubusercontent.com/4643658/180269047-417226dd-ce8f-41a6-92ee-e6ed7d279cb6.png"> | <img width="500" alt="On the next run, the action reports cache hit, and the long task is skipped" src="https://user-images.githubusercontent.com/4643658/180269038-9f896490-619f-4fd8-b801-af01b62b1981.png"> |
 
 <!-- action-docs-description -->
+
 ## Description
 
 Allows to skip a job if it already succeeded for the same repo tree hash. Uses S3 for caching.
-
 
 <!-- action-docs-description -->
 
@@ -34,29 +34,27 @@ allow to read and write to the S3 bucket provided as input. Use the
 that's the case.
 
 <!-- action-docs-inputs -->
+
 ## Inputs
 
-| parameter | description | required | default |
-| - | - | - | - |
-| bucket-name | Name of the S3 bucket to use for storing cache files. The job needs to have AWS credentials configured to allow read/write from this bucket. | `true` |  |
-| key-prefix | Key prefix to add to the cache files key. By default the job ID is used. The full key used for the cache files is `cache/${repoOwner}/${repoName}/${keyPrefix}/${treeHash}` | `false` | ${{ github.job }} |
-| aws-region | AWS region for the S3 bucket used for storing hashes. | `false` | ${{ env.AWS_REGION }} |
-| aws-access-key-id | AWS Access Key for the AWS account managing the S3 bucket used for storing hashes. | `false` | ${{ env.AWS_ACCESS_KEY_ID }} |
-| aws-secret-access-key | AWS Secret Access Key for the AWS account managing the S3 bucket used for storing hashes. | `false` | ${{ env.AWS_SECRET_ACCESS_KEY }} |
-
-
+| parameter             | description                                                                                                                                                                 | required | default                          |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | -------------------------------- |
+| bucket-name           | Name of the S3 bucket to use for storing cache files. The job needs to have AWS credentials configured to allow read/write from this bucket.                                | `true`   |                                  |
+| key-prefix            | Key prefix to add to the cache files key. By default the job ID is used. The full key used for the cache files is `cache/${repoOwner}/${repoName}/${keyPrefix}/${treeHash}` | `false`  | ${{ github.job }}                |
+| aws-region            | AWS region for the S3 bucket used for storing hashes.                                                                                                                       | `false`  | ${{ env.AWS_REGION }}            |
+| aws-access-key-id     | AWS Access Key for the AWS account managing the S3 bucket used for storing hashes.                                                                                          | `false`  | ${{ env.AWS_ACCESS_KEY_ID }}     |
+| aws-secret-access-key | AWS Secret Access Key for the AWS account managing the S3 bucket used for storing hashes.                                                                                   | `false`  | ${{ env.AWS_SECRET_ACCESS_KEY }} |
 
 <!-- action-docs-inputs -->
 
 <!-- action-docs-outputs -->
+
 ## Outputs
 
-| parameter | description |
-| - | - |
+| parameter | description                                                                     |
+| --------- | ------------------------------------------------------------------------------- |
 | processed | Indicates if the job has already been performed for the current repo tree hash. |
-| hash | The repo tree hash which was used for caching. |
-
-
+| hash      | The repo tree hash which was used for caching.                                  |
 
 <!-- action-docs-outputs -->
 
@@ -77,10 +75,10 @@ that's the case.
 ```
 
 <!-- action-docs-runs -->
+
 ## Runs
 
 This action is a `node16` action.
-
 
 <!-- action-docs-runs -->
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ that's the case.
 | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | -------------------------------- |
 | bucket-name           | Name of the S3 bucket to use for storing cache files. The job needs to have AWS credentials configured to allow read/write from this bucket.                                | `true`   |                                  |
 | key-prefix            | Key prefix to add to the cache files key. By default the job ID is used. The full key used for the cache files is `cache/${repoOwner}/${repoName}/${keyPrefix}/${treeHash}` | `false`  | ${{ github.job }}                |
-| aws-region            | AWS region for the S3 bucket used for storing hashes.                                                                                                                       | `false`  | ${{ env.AWS_REGION }}            |
-| aws-access-key-id     | AWS Access Key for the AWS account managing the S3 bucket used for storing cache files.                                                                                     | `false`  | ${{ env.AWS_ACCESS_KEY_ID }}     |
-| aws-secret-access-key | AWS Secret Access Key for the AWS account managing the S3 bucket used for storing hashes.                                                                                   | `false`  | ${{ env.AWS_SECRET_ACCESS_KEY }} |
+| aws-region            | AWS region for the S3 bucket used for cache files.                                                                                                                          | `false`  | ${{ env.AWS_REGION }}            |
+| aws-access-key-id     | Access Key ID for an IAM user with permissions to read/write to the S3 bucket used for cache files.                                                                         | `false`  | ${{ env.AWS_ACCESS_KEY_ID }}     |
+| aws-secret-access-key | Secret Access Key for an IAM user with permissions to read/write to the S3 bucket used for cache files.                                                                     | `false`  | ${{ env.AWS_SECRET_ACCESS_KEY }} |
 
 <!-- action-docs-inputs -->
 
@@ -51,10 +51,10 @@ that's the case.
 
 ## Outputs
 
-| parameter | description                                                                     |
-| --------- | ------------------------------------------------------------------------------- |
-| processed | Indicates if the job has already been performed for the current repo tree hash. |
-| hash      | The repo tree hash which was used for caching.                                  |
+| parameter | description                                                                 |
+| --------- | --------------------------------------------------------------------------- |
+| processed | Indicates if the job has already been performed for the current repo state. |
+| hash      | The repo tree hash which was used for caching.                              |
 
 <!-- action-docs-outputs -->
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## Description
 
-Allows to skip a job if it already succeeded for the same repo tree hash. Uses S3 for caching.
+Allows to skip a job if it already succeeded for the same repo state. Uses S3 for caching.
 
 <!-- action-docs-description -->
 

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: S3 Cache Action
 description:
-    Allows to skip a job if it already succeeded for the same repo tree hash. Uses S3 for caching.
+    Allows to skip a job if it already succeeded for the same repo state. Uses S3 for caching.
 author: Pleo OSS
 inputs:
     bucket-name:
@@ -15,23 +15,24 @@ inputs:
         default: ${{ github.job }}
         required: false
     aws-region:
-        description: AWS region for the S3 bucket used for storing hashes.
+        description: AWS region for the S3 bucket used for cache files.
         default: ${{ env.AWS_REGION }}
         required: false
     aws-access-key-id:
         description:
-            AWS Access Key for the AWS account managing the S3 bucket used for storing hashes.
+            Access Key ID for an IAM user with permissions to read/write to the S3 bucket used for
+            cache files.
         default: ${{ env.AWS_ACCESS_KEY_ID }}
         required: false
     aws-secret-access-key:
         description:
-            AWS Secret Access Key for the AWS account managing the S3 bucket used for storing
-            hashes.
+            Secret Access Key for an IAM user with permissions to read/write to the S3 bucket used
+            for cache files.
         default: ${{ env.AWS_SECRET_ACCESS_KEY }}
         required: false
 outputs:
     processed:
-        description: Indicates if the job has already been performed for the current repo tree hash.
+        description: Indicates if the job has already been performed for the current repo state.
     hash:
         description: The repo tree hash which was used for caching.
 runs:

--- a/action.yml
+++ b/action.yml
@@ -1,24 +1,39 @@
 name: S3 Cache Action
 description:
-    Allows to skip a job if it already succeeded for the same repo state. Uses S3 for caching.
+    Allows to skip a job if it already succeeded for the same repo tree hash. Uses S3 for caching.
 author: Pleo OSS
 inputs:
-    bucket_name:
+    bucket-name:
         description:
             Name of the S3 bucket to use for storing cache files. The job needs to have AWS
             credentials configured to allow read/write from this bucket.
         required: true
-    key_prefix:
+    key-prefix:
         description:
             Key prefix to add to the cache files key. By default the job ID is used. The full key
             used for the cache files is "cache/${repoOwner}/${repoName}/${keyPrefix}/${treeHash}"
         default: ${{ github.job }}
         required: false
+    aws-region:
+        description: AWS region for the S3 bucket used for storing hashes.
+        default: ${{ env.AWS_REGION }}
+        required: false
+    aws-access-key-id:
+        description:
+            AWS Access Key for the AWS account managing the S3 bucket used for storing hashes.
+        default: ${{ env.AWS_ACCESS_KEY_ID }}
+        required: false
+    aws-secret-access-key:
+        description:
+            AWS Secret Access Key for the AWS account managing the S3 bucket used for storing
+            hashes.
+        default: ${{ env.AWS_SECRET_ACCESS_KEY }}
+        required: false
 outputs:
     processed:
-        description: Indicates if the job has already been performed for the current repo tree hash
+        description: Indicates if the job has already been performed for the current repo tree hash.
     hash:
-        description: The repo tree hash which was used for caching
+        description: The repo tree hash which was used for caching.
 runs:
     using: node16
     main: dist/restore/index.js

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -10223,7 +10223,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getCurrentRepoTreeHash = exports.getTreeHashForCommitHash = exports.runAction = exports.copyFileToS3 = exports.writeLineToFile = exports.fileExistsInS3 = void 0;
+exports.getCurrentRepoTreeHash = exports.getTreeHashForCommitHash = exports.runAction = exports.copyFileToS3 = exports.writeLineToFile = exports.fileExistsInS3 = exports.toAWSEnvironmentVariables = void 0;
 const exec_1 = __nccwpck_require__(1514);
 const core = __importStar(__nccwpck_require__(2186));
 const toAWSEnvironmentVariables = (options) => ({
@@ -10231,6 +10231,7 @@ const toAWSEnvironmentVariables = (options) => ({
     AWS_ACCESS_KEY_ID: options.accessKeyId,
     AWS_SECRET_ACCESS_KEY: options.secretAccessKey
 });
+exports.toAWSEnvironmentVariables = toAWSEnvironmentVariables;
 /**
  * Checks if a file with a given key exists in the specified S3 bucket
  * Uses "aws s3api head-object"
@@ -10241,7 +10242,7 @@ const toAWSEnvironmentVariables = (options) => ({
 function fileExistsInS3({ key, bucket, awsOptions }) {
     return __awaiter(this, void 0, void 0, function* () {
         return execIsSuccessful('aws s3api head-object', [`--bucket=${bucket}`, `--key=${key}`], {
-            env: toAWSEnvironmentVariables(awsOptions)
+            env: (0, exports.toAWSEnvironmentVariables)(awsOptions)
         });
     });
 }
@@ -10288,7 +10289,7 @@ exports.writeLineToFile = writeLineToFile;
 function copyFileToS3({ path, key, bucket, awsOptions }) {
     return __awaiter(this, void 0, void 0, function* () {
         yield (0, exec_1.exec)('aws s3 cp', [path, `s3://${bucket}/${key}`], {
-            env: toAWSEnvironmentVariables(awsOptions)
+            env: (0, exports.toAWSEnvironmentVariables)(awsOptions)
         });
     });
 }

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -10237,6 +10237,7 @@ exports.toAWSEnvironmentVariables = toAWSEnvironmentVariables;
  * Uses "aws s3api head-object"
  * @param options.key - The key of a file in the S3 bucket
  * @param options.bucket - The name of the S3 bucket (globally unique)
+ * @param options.awsOptions - The AWS configuration for the S3 bucket (region, access key ID, secret access key)
  * @returns fileExists - boolean indicating if the file exists
  */
 function fileExistsInS3({ key, bucket, awsOptions }) {
@@ -10284,6 +10285,7 @@ exports.writeLineToFile = writeLineToFile;
  * @param options.path - The local path of the file (relative to working dir)
  * @param options.key - The key of a file to create in the S3 bucket
  * @param options.bucket - The name of the S3 bucket (globally unique)
+ * @param options.awsOptions - The AWS configuration for the S3 bucket (region, access key ID, secret access key)
  * @returns exitCode - shell command exit code
  */
 function copyFileToS3({ path, key, bucket, awsOptions }) {

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -3415,6 +3415,7 @@ exports.toAWSEnvironmentVariables = toAWSEnvironmentVariables;
  * Uses "aws s3api head-object"
  * @param options.key - The key of a file in the S3 bucket
  * @param options.bucket - The name of the S3 bucket (globally unique)
+ * @param options.awsOptions - The AWS configuration for the S3 bucket (region, access key ID, secret access key)
  * @returns fileExists - boolean indicating if the file exists
  */
 function fileExistsInS3({ key, bucket, awsOptions }) {
@@ -3462,6 +3463,7 @@ exports.writeLineToFile = writeLineToFile;
  * @param options.path - The local path of the file (relative to working dir)
  * @param options.key - The key of a file to create in the S3 bucket
  * @param options.bucket - The name of the S3 bucket (globally unique)
+ * @param options.awsOptions - The AWS configuration for the S3 bucket (region, access key ID, secret access key)
  * @returns exitCode - shell command exit code
  */
 function copyFileToS3({ path, key, bucket, awsOptions }) {

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -3401,7 +3401,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getCurrentRepoTreeHash = exports.getTreeHashForCommitHash = exports.runAction = exports.copyFileToS3 = exports.writeLineToFile = exports.fileExistsInS3 = void 0;
+exports.getCurrentRepoTreeHash = exports.getTreeHashForCommitHash = exports.runAction = exports.copyFileToS3 = exports.writeLineToFile = exports.fileExistsInS3 = exports.toAWSEnvironmentVariables = void 0;
 const exec_1 = __nccwpck_require__(514);
 const core = __importStar(__nccwpck_require__(186));
 const toAWSEnvironmentVariables = (options) => ({
@@ -3409,6 +3409,7 @@ const toAWSEnvironmentVariables = (options) => ({
     AWS_ACCESS_KEY_ID: options.accessKeyId,
     AWS_SECRET_ACCESS_KEY: options.secretAccessKey
 });
+exports.toAWSEnvironmentVariables = toAWSEnvironmentVariables;
 /**
  * Checks if a file with a given key exists in the specified S3 bucket
  * Uses "aws s3api head-object"
@@ -3419,7 +3420,7 @@ const toAWSEnvironmentVariables = (options) => ({
 function fileExistsInS3({ key, bucket, awsOptions }) {
     return __awaiter(this, void 0, void 0, function* () {
         return execIsSuccessful('aws s3api head-object', [`--bucket=${bucket}`, `--key=${key}`], {
-            env: toAWSEnvironmentVariables(awsOptions)
+            env: (0, exports.toAWSEnvironmentVariables)(awsOptions)
         });
     });
 }
@@ -3466,7 +3467,7 @@ exports.writeLineToFile = writeLineToFile;
 function copyFileToS3({ path, key, bucket, awsOptions }) {
     return __awaiter(this, void 0, void 0, function* () {
         yield (0, exec_1.exec)('aws s3 cp', [path, `s3://${bucket}/${key}`], {
-            env: toAWSEnvironmentVariables(awsOptions)
+            env: (0, exports.toAWSEnvironmentVariables)(awsOptions)
         });
     });
 }

--- a/src/restore.test.ts
+++ b/src/restore.test.ts
@@ -5,6 +5,12 @@ import * as utils from './utils'
 jest.mock('./utils')
 const mockedUtils = jest.mocked(utils, true)
 
+const awsOptions = {
+    region: 'eu-west-1',
+    accessKeyId: 'verycoolkey',
+    secretAccessKey: 'verycoolsecretkey'
+}
+
 beforeEach(() => jest.clearAllMocks())
 
 describe(`S3 Cache Action - Restore cache`, () => {
@@ -22,7 +28,8 @@ describe(`S3 Cache Action - Restore cache`, () => {
             const output = await restoreS3Cache({
                 bucket: 'my-bucket',
                 keyPrefix: 'horse',
-                repo: {owner: 'my-org', repo: 'my-repo'}
+                repo: {owner: 'my-org', repo: 'my-repo'},
+                awsOptions
             })
 
             expect(output.key).toBe(`cache/my-org/my-repo/horse/${treeHash}`)
@@ -32,7 +39,8 @@ describe(`S3 Cache Action - Restore cache`, () => {
             expect(mockedUtils.fileExistsInS3).toHaveBeenCalledTimes(1)
             expect(mockedUtils.fileExistsInS3).toHaveBeenCalledWith({
                 bucket: 'my-bucket',
-                key: `cache/my-org/my-repo/horse/${treeHash}`
+                key: `cache/my-org/my-repo/horse/${treeHash}`,
+                awsOptions: awsOptions
             })
         }
     )
@@ -51,7 +59,8 @@ describe(`S3 Cache Action - Restore cache`, () => {
             const output = await restoreS3Cache({
                 bucket: 'my-other-bucket',
                 keyPrefix: 'horse',
-                repo: {owner: 'my-org', repo: 'my-repo'}
+                repo: {owner: 'my-org', repo: 'my-repo'},
+                awsOptions
             })
 
             expect(output.key).toBe(`cache/my-org/my-repo/horse/${treeHash}`)
@@ -61,7 +70,8 @@ describe(`S3 Cache Action - Restore cache`, () => {
             expect(mockedUtils.fileExistsInS3).toHaveBeenCalledTimes(1)
             expect(mockedUtils.fileExistsInS3).toHaveBeenCalledWith({
                 bucket: 'my-other-bucket',
-                key: `cache/my-org/my-repo/horse/${treeHash}`
+                key: `cache/my-org/my-repo/horse/${treeHash}`,
+                awsOptions: awsOptions
             })
         }
     )

--- a/src/save.test.ts
+++ b/src/save.test.ts
@@ -5,6 +5,12 @@ import * as utils from './utils'
 jest.mock('./utils')
 const mockedUtils = jest.mocked(utils, true)
 
+const awsOptions = {
+    region: 'eu-west-1',
+    accessKeyId: 'verycoolkey',
+    secretAccessKey: 'verycoolsecretkey'
+}
+
 beforeEach(() => jest.clearAllMocks())
 
 describe(`S3 Cache Action - Save cache`, () => {
@@ -19,7 +25,8 @@ describe(`S3 Cache Action - Save cache`, () => {
             await saveS3Cache({
                 bucket: 'my-bucket',
                 hash: treeHash,
-                key: 'my-org/my-repo/cache/horse'
+                key: 'my-org/my-repo/cache/horse',
+                awsOptions
             })
 
             expect(mockedUtils.writeLineToFile).toHaveBeenCalledTimes(1)
@@ -32,7 +39,8 @@ describe(`S3 Cache Action - Save cache`, () => {
             expect(mockedUtils.copyFileToS3).toHaveBeenCalledWith({
                 path: treeHash,
                 bucket: 'my-bucket',
-                key: 'my-org/my-repo/cache/horse'
+                key: 'my-org/my-repo/cache/horse',
+                awsOptions
             })
         }
     )
@@ -46,7 +54,8 @@ describe(`S3 Cache Action - Save cache`, () => {
             await saveS3Cache({
                 bucket: 'my-bucket',
                 hash: '',
-                key: ''
+                key: '',
+                awsOptions
             })
 
             expect(mockedUtils.writeLineToFile).not.toHaveBeenCalled()

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,12 +1,17 @@
 import * as utils from './utils'
 import {exec} from '@actions/exec'
-import * as core from '@actions/core'
 
 jest.mock('@actions/core')
 jest.mock('@actions/exec')
 
 // just making sure the mock methods are correctly typed
 const mockedExec = exec as jest.MockedFunction<typeof exec>
+
+const awsOptions = {
+    region: 'eu-west-1',
+    accessKeyId: 'verycoolkey',
+    secretAccessKey: 'verycoolsecretkey'
+}
 
 // reset the counter on mock fn calls after every test
 beforeEach(() => jest.clearAllMocks())
@@ -44,31 +49,47 @@ describe(`Actions Utils`, () => {
     describe('S3 Utils', () => {
         test(`fileExistsInS3 uses AWS CLI to check for of an object in S3 bucket, returns true if it exists`, async () => {
             mockedExec.mockResolvedValue(0)
-            const output = await utils.fileExistsInS3({key: 'my/key', bucket: 'my-bucket'})
-            expect(mockedExec).toHaveBeenCalledWith('aws s3api head-object', [
-                '--bucket=my-bucket',
-                '--key=my/key'
-            ])
+            const output = await utils.fileExistsInS3({
+                key: 'my/key',
+                bucket: 'my-bucket',
+                awsOptions
+            })
+            expect(mockedExec).toHaveBeenCalledWith(
+                'aws s3api head-object',
+                ['--bucket=my-bucket', '--key=my/key'],
+                {env: utils.toAWSEnvironmentVariables(awsOptions)}
+            )
             expect(output).toBe(true)
         })
 
         test(`fileExistsInS3 uses AWS CLI to check for of an object in S3 bucket, returns true if it exists`, async () => {
             mockedExec.mockRejectedValue(255)
-            const output = await utils.fileExistsInS3({key: 'my/key', bucket: 'my-bucket'})
-            expect(mockedExec).toHaveBeenCalledWith('aws s3api head-object', [
-                '--bucket=my-bucket',
-                '--key=my/key'
-            ])
+            const output = await utils.fileExistsInS3({
+                key: 'my/key',
+                bucket: 'my-bucket',
+                awsOptions
+            })
+            expect(mockedExec).toHaveBeenCalledWith(
+                'aws s3api head-object',
+                ['--bucket=my-bucket', '--key=my/key'],
+                {env: utils.toAWSEnvironmentVariables(awsOptions)}
+            )
             expect(output).toBe(false)
         })
 
         test(`copyFileToS3 uses AWS CLI to copy a local file to S3 bucket`, async () => {
             mockedExec.mockResolvedValue(0)
-            await utils.copyFileToS3({path: '/some/file', key: 'my/key', bucket: 'my-bucket'})
-            expect(mockedExec).toHaveBeenCalledWith('aws s3 cp', [
-                '/some/file',
-                's3://my-bucket/my/key'
-            ])
+            await utils.copyFileToS3({
+                path: '/some/file',
+                key: 'my/key',
+                bucket: 'my-bucket',
+                awsOptions
+            })
+            expect(mockedExec).toHaveBeenCalledWith(
+                'aws s3 cp',
+                ['/some/file', 's3://my-bucket/my/key'],
+                {env: utils.toAWSEnvironmentVariables(awsOptions)}
+            )
         })
     })
 })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,6 +18,7 @@ export const toAWSEnvironmentVariables = (options: AWSOptions) => ({
  * Uses "aws s3api head-object"
  * @param options.key - The key of a file in the S3 bucket
  * @param options.bucket - The name of the S3 bucket (globally unique)
+ * @param options.awsOptions - The AWS configuration for the S3 bucket (region, access key ID, secret access key)
  * @returns fileExists - boolean indicating if the file exists
  */
 export async function fileExistsInS3({
@@ -67,6 +68,7 @@ export async function writeLineToFile({text, path}: {text: string; path: string}
  * @param options.path - The local path of the file (relative to working dir)
  * @param options.key - The key of a file to create in the S3 bucket
  * @param options.bucket - The name of the S3 bucket (globally unique)
+ * @param options.awsOptions - The AWS configuration for the S3 bucket (region, access key ID, secret access key)
  * @returns exitCode - shell command exit code
  */
 export async function copyFileToS3({


### PR DESCRIPTION
This PR will change the Action to take three AWS CLI environment variables: 
- region
- Access Key ID
- Secret Access Key

This is done to avoid errors when running the post-step of the action when the AWS CLI environment variables have been cleared in the [`configure-aws-credentials`](https://github.com/aws-actions/configure-aws-credentials) post-step. In certain cases the post-step of `configure-aws-credentials` will remove the environment variables for AWS CLI, leading to `s3-cache-action` failing because of missing variables. 

BREAKING CHANGE: The Action now takes three optional AWS CLI environment variables for specifying region, Access Key ID and Secret Access Key. The parameters for the Action have also been renamed to follow kebab-case like GitHub's Actions.

The Action takes AWS CLI parameters in order to avoid errors when running the post-step of the action when the AWS CLI environment variables have been cleared in the [`configure-aws-credentials`](https://github.com/aws-actions/configure-aws-credentials) post-step. In certain cases the post-step of `configure-aws-credentials` will remove the environment variables for AWS CLI, leading to `s3-cache-action` failing because of missing variables.