### PR TITLE
feat!: Fix AWS environment parameters not injecting as expected 

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ that's the case.
 
 ## Inputs
 
-| parameter             | description                                                                                                                                                                 | required | default                          |
-| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | -------------------------------- |
-| bucket-name           | Name of the S3 bucket to use for storing cache files. The job needs to have AWS credentials configured to allow read/write from this bucket.                                | `true`   |                                  |
-| key-prefix            | Key prefix to add to the cache files key. By default the job ID is used. The full key used for the cache files is `cache/${repoOwner}/${repoName}/${keyPrefix}/${treeHash}` | `false`  | ${{ github.job }}                |
-| aws-region            | AWS region for the S3 bucket used for cache files.                                                                                                                          | `false`  | ${{ env.AWS_REGION }}            |
-| aws-access-key-id     | Access Key ID for an IAM user with permissions to read/write to the S3 bucket used for cache files.                                                                         | `false`  | ${{ env.AWS_ACCESS_KEY_ID }}     |
-| aws-secret-access-key | Secret Access Key for an IAM user with permissions to read/write to the S3 bucket used for cache files.                                                                     | `false`  | ${{ env.AWS_SECRET_ACCESS_KEY }} |
+| parameter             | description                                                                                                                                                                 | required | default           |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------------- |
+| bucket-name           | Name of the S3 bucket to use for storing cache files. The job needs to have AWS credentials configured to allow read/write from this bucket.                                | `true`   |                   |
+| key-prefix            | Key prefix to add to the cache files key. By default the job ID is used. The full key used for the cache files is `cache/${repoOwner}/${repoName}/${keyPrefix}/${treeHash}` | `false`  | ${{ github.job }} |
+| aws-region            | AWS region for the S3 bucket used for cache files. Defaults to `env.AWS_REGION` if available.                                                                               | `true`   |                   |
+| aws-access-key-id     | Access Key ID for an IAM user with permissions to read/write to the S3 bucket used for cache files. Defaults to `env.AWS_ACCESS_KEY_ID` if available.                       | `true`   |                   |
+| aws-secret-access-key | Secret Access Key for an IAM user with permissions to read/write to the S3 bucket used for cache files. Defaults to `env.AWS_SECRET_ACCESS_KEY` if available.               | `true`   |                   |
 
 <!-- action-docs-inputs -->
 

--- a/action.yml
+++ b/action.yml
@@ -15,21 +15,20 @@ inputs:
         default: ${{ github.job }}
         required: false
     aws-region:
-        description: AWS region for the S3 bucket used for cache files.
-        default: ${{ env.AWS_REGION }}
-        required: false
+        description:
+            AWS region for the S3 bucket used for cache files. Defaults to `env.AWS_REGION` if
+            available.
+        required: true
     aws-access-key-id:
         description:
             Access Key ID for an IAM user with permissions to read/write to the S3 bucket used for
-            cache files.
-        default: ${{ env.AWS_ACCESS_KEY_ID }}
-        required: false
+            cache files. Defaults to `env.AWS_ACCESS_KEY_ID` if available.
+        required: true
     aws-secret-access-key:
         description:
             Secret Access Key for an IAM user with permissions to read/write to the S3 bucket used
-            for cache files.
-        default: ${{ env.AWS_SECRET_ACCESS_KEY }}
-        required: false
+            for cache files. Defaults to `env.AWS_SECRET_ACCESS_KEY` if available.
+        required: true
 outputs:
     processed:
         description: Indicates if the job has already been performed for the current repo state.

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -10146,26 +10146,26 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.restoreS3Cache = void 0;
-const core = __importStar(__nccwpck_require__(2186));
+const core_1 = __nccwpck_require__(2186);
 const github = __importStar(__nccwpck_require__(5438));
 const utils_1 = __nccwpck_require__(1314);
 (0, utils_1.runAction)(() => __awaiter(void 0, void 0, void 0, function* () {
-    const bucket = core.getInput('bucket_name', { required: true });
-    const keyPrefix = core.getInput('key_prefix');
+    const bucket = (0, core_1.getInput)('bucket_name', { required: true });
+    const keyPrefix = (0, core_1.getInput)('key_prefix');
     const repo = github.context.repo;
     const awsOptions = {
-        region: core.getInput('aws-region'),
-        accessKeyId: core.getInput('aws-access-key-id'),
-        secretAccessKey: core.getInput('aws-secret-access-key')
+        region: (0, core_1.getInput)('aws-region'),
+        accessKeyId: (0, core_1.getInput)('aws-access-key-id'),
+        secretAccessKey: (0, core_1.getInput)('aws-secret-access-key')
     };
     const output = yield restoreS3Cache({ bucket, keyPrefix, repo, awsOptions });
     // Saving key and hash in "state" which can be retrieved by the
     // "post" run of the action (save.ts)
     // https://github.com/actions/toolkit/tree/daf8bb00606d37ee2431d9b1596b88513dcf9c59/packages/core#action-state
-    core.saveState('key', output.key);
-    core.saveState('hash', output.treeHash);
-    core.setOutput('processed', output.processed);
-    core.setOutput('hash', output.treeHash);
+    (0, core_1.saveState)('key', output.key);
+    (0, core_1.saveState)('hash', output.treeHash);
+    (0, core_1.setOutput)('processed', output.processed);
+    (0, core_1.setOutput)('hash', output.treeHash);
 }));
 function restoreS3Cache({ bucket, keyPrefix, repo, awsOptions }) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -10173,10 +10173,10 @@ function restoreS3Cache({ bucket, keyPrefix, repo, awsOptions }) {
         const key = `cache/${repo.owner}/${repo.repo}/${keyPrefix}/${treeHash}`;
         const fileExists = yield (0, utils_1.fileExistsInS3)({ key, bucket, awsOptions });
         if (fileExists) {
-            core.info(`Tree hash ${treeHash} already processed.`);
+            (0, core_1.info)(`Tree hash ${treeHash} already processed.`);
             return { processed: true, treeHash, key };
         }
-        core.info(`Tree hash ${treeHash} has not been processed yet.`);
+        (0, core_1.info)(`Tree hash ${treeHash} has not been processed yet.`);
         return { processed: false, treeHash, key };
     });
 }
@@ -10190,29 +10190,6 @@ exports.restoreS3Cache = restoreS3Cache;
 
 "use strict";
 
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-    __setModuleDefault(result, mod);
-    return result;
-};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -10225,7 +10202,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getCurrentRepoTreeHash = exports.getTreeHashForCommitHash = exports.runAction = exports.copyFileToS3 = exports.writeLineToFile = exports.fileExistsInS3 = exports.toAWSEnvironmentVariables = void 0;
 const exec_1 = __nccwpck_require__(1514);
-const core = __importStar(__nccwpck_require__(2186));
+const core_1 = __nccwpck_require__(2186);
 const toAWSEnvironmentVariables = (options) => ({
     AWS_REGION: options.region,
     AWS_ACCESS_KEY_ID: options.accessKeyId,
@@ -10308,11 +10285,11 @@ function runAction(action) {
         }
         catch (error) {
             if (error instanceof Error) {
-                core.error((_a = error.stack) !== null && _a !== void 0 ? _a : error.message);
-                core.setFailed(error);
+                (0, core_1.error)((_a = error.stack) !== null && _a !== void 0 ? _a : error.message);
+                (0, core_1.setFailed)(error);
             }
             else {
-                core.setFailed(String(error));
+                (0, core_1.setFailed)(String(error));
             }
         }
     });

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -3298,29 +3298,6 @@ exports.debug = debug; // for test
  *
  * Uploads a cache file to the S3 bucket, if the file was not uploaded before.
  */
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-    __setModuleDefault(result, mod);
-    return result;
-};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -3332,30 +3309,30 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.saveS3Cache = void 0;
-const core = __importStar(__nccwpck_require__(186));
+const core_1 = __nccwpck_require__(186);
 const utils_1 = __nccwpck_require__(314);
 (0, utils_1.runAction)(() => {
-    const bucket = core.getInput('bucket_name', { required: true });
-    const hash = core.getState('hash');
-    const key = core.getState('key');
+    const bucket = (0, core_1.getInput)('bucket_name', { required: true });
+    const hash = (0, core_1.getState)('hash');
+    const key = (0, core_1.getState)('key');
     const awsOptions = {
-        region: core.getInput('aws-region'),
-        accessKeyId: core.getInput('aws-access-key-id'),
-        secretAccessKey: core.getInput('aws-secret-access-key')
+        region: (0, core_1.getInput)('aws-region'),
+        accessKeyId: (0, core_1.getInput)('aws-access-key-id'),
+        secretAccessKey: (0, core_1.getInput)('aws-secret-access-key')
     };
     return saveS3Cache({ bucket, hash, key, awsOptions });
 });
 function saveS3Cache({ bucket, hash, key, awsOptions }) {
     return __awaiter(this, void 0, void 0, function* () {
         if (!hash || !key) {
-            core.info(`Tree hash already processed, skipping saving the cache file.`);
+            (0, core_1.info)(`Tree hash already processed, skipping saving the cache file.`);
             return;
         }
         // The content of the file doesn't really matter,
         // since we're only checking if the file exists
         yield (0, utils_1.writeLineToFile)({ text: hash, path: hash });
         yield (0, utils_1.copyFileToS3)({ path: hash, bucket, key, awsOptions });
-        core.info(`Tree hash ${hash} was processed, saved the ${key} cache file.`);
+        (0, core_1.info)(`Tree hash ${hash} was processed, saved the ${key} cache file.`);
     });
 }
 exports.saveS3Cache = saveS3Cache;
@@ -3368,29 +3345,6 @@ exports.saveS3Cache = saveS3Cache;
 
 "use strict";
 
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-    __setModuleDefault(result, mod);
-    return result;
-};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -3403,7 +3357,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getCurrentRepoTreeHash = exports.getTreeHashForCommitHash = exports.runAction = exports.copyFileToS3 = exports.writeLineToFile = exports.fileExistsInS3 = exports.toAWSEnvironmentVariables = void 0;
 const exec_1 = __nccwpck_require__(514);
-const core = __importStar(__nccwpck_require__(186));
+const core_1 = __nccwpck_require__(186);
 const toAWSEnvironmentVariables = (options) => ({
     AWS_REGION: options.region,
     AWS_ACCESS_KEY_ID: options.accessKeyId,
@@ -3486,11 +3440,11 @@ function runAction(action) {
         }
         catch (error) {
             if (error instanceof Error) {
-                core.error((_a = error.stack) !== null && _a !== void 0 ? _a : error.message);
-                core.setFailed(error);
+                (0, core_1.error)((_a = error.stack) !== null && _a !== void 0 ? _a : error.message);
+                (0, core_1.setFailed)(error);
             }
             else {
-                core.setFailed(String(error));
+                (0, core_1.setFailed)(String(error));
             }
         }
     });

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -6,18 +6,18 @@
  * the result as the `process` output variable, which can be used by the following steps of the job.
  */
 
-import * as core from '@actions/core'
+import {getInput, saveState, setOutput, info} from '@actions/core'
 import * as github from '@actions/github'
 import {getCurrentRepoTreeHash, fileExistsInS3, runAction, AWSOptions} from './utils'
 
 runAction(async () => {
-    const bucket = core.getInput('bucket_name', {required: true})
-    const keyPrefix = core.getInput('key_prefix')
+    const bucket = getInput('bucket_name', {required: true})
+    const keyPrefix = getInput('key_prefix')
     const repo = github.context.repo
     const awsOptions = {
-        region: core.getInput('aws-region'),
-        accessKeyId: core.getInput('aws-access-key-id'),
-        secretAccessKey: core.getInput('aws-secret-access-key')
+        region: getInput('aws-region'),
+        accessKeyId: getInput('aws-access-key-id'),
+        secretAccessKey: getInput('aws-secret-access-key')
     }
 
     const output = await restoreS3Cache({bucket, keyPrefix, repo, awsOptions})
@@ -25,11 +25,11 @@ runAction(async () => {
     // Saving key and hash in "state" which can be retrieved by the
     // "post" run of the action (save.ts)
     // https://github.com/actions/toolkit/tree/daf8bb00606d37ee2431d9b1596b88513dcf9c59/packages/core#action-state
-    core.saveState('key', output.key)
-    core.saveState('hash', output.treeHash)
+    saveState('key', output.key)
+    saveState('hash', output.treeHash)
 
-    core.setOutput('processed', output.processed)
-    core.setOutput('hash', output.treeHash)
+    setOutput('processed', output.processed)
+    setOutput('hash', output.treeHash)
 })
 
 type RestoreS3CacheActionArgs = {
@@ -51,10 +51,10 @@ export async function restoreS3Cache({
     const fileExists = await fileExistsInS3({key, bucket, awsOptions})
 
     if (fileExists) {
-        core.info(`Tree hash ${treeHash} already processed.`)
+        info(`Tree hash ${treeHash} already processed.`)
         return {processed: true, treeHash, key}
     }
 
-    core.info(`Tree hash ${treeHash} has not been processed yet.`)
+    info(`Tree hash ${treeHash} has not been processed yet.`)
     return {processed: false, treeHash, key}
 }

--- a/src/save.ts
+++ b/src/save.ts
@@ -6,17 +6,17 @@
  * Uploads a cache file to the S3 bucket, if the file was not uploaded before.
  */
 
-import * as core from '@actions/core'
+import {getInput, getState, info} from '@actions/core'
 import {writeLineToFile, copyFileToS3, runAction, AWSOptions} from './utils'
 
 runAction(() => {
-    const bucket = core.getInput('bucket_name', {required: true})
-    const hash = core.getState('hash')
-    const key = core.getState('key')
+    const bucket = getInput('bucket_name', {required: true})
+    const hash = getState('hash')
+    const key = getState('key')
     const awsOptions = {
-        region: core.getInput('aws-region'),
-        accessKeyId: core.getInput('aws-access-key-id'),
-        secretAccessKey: core.getInput('aws-secret-access-key')
+        region: getInput('aws-region'),
+        accessKeyId: getInput('aws-access-key-id'),
+        secretAccessKey: getInput('aws-secret-access-key')
     }
 
     return saveS3Cache({bucket, hash, key, awsOptions})
@@ -31,7 +31,7 @@ type SaveS3CacheActionArgs = {
 
 export async function saveS3Cache({bucket, hash, key, awsOptions}: SaveS3CacheActionArgs) {
     if (!hash || !key) {
-        core.info(`Tree hash already processed, skipping saving the cache file.`)
+        info(`Tree hash already processed, skipping saving the cache file.`)
         return
     }
 
@@ -40,5 +40,5 @@ export async function saveS3Cache({bucket, hash, key, awsOptions}: SaveS3CacheAc
     await writeLineToFile({text: hash, path: hash})
     await copyFileToS3({path: hash, bucket, key, awsOptions})
 
-    core.info(`Tree hash ${hash} was processed, saved the ${key} cache file.`)
+    info(`Tree hash ${hash} was processed, saved the ${key} cache file.`)
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import {exec, ExecOptions} from '@actions/exec'
-import * as core from '@actions/core'
+import {error as addError, setFailed} from '@actions/core'
 
 export interface AWSOptions {
     region: string
@@ -96,10 +96,10 @@ export async function runAction(action: () => Promise<unknown>) {
         return action()
     } catch (error: unknown) {
         if (error instanceof Error) {
-            core.error(error.stack ?? error.message)
-            core.setFailed(error)
+            addError(error.stack ?? error.message)
+            setFailed(error)
         } else {
-            core.setFailed(String(error))
+            setFailed(String(error))
         }
     }
 }


### PR DESCRIPTION
This will make AWS parameters required, since `${{ env }}` parameters aren't allowed for `action.yml` `default` definitions.
