### PR TITLE
Use Auto for releasing

### DIFF
--- a/.autorc.json
+++ b/.autorc.json
@@ -5,34 +5,34 @@
     "onlyPublishWithReleaseLabel": false,
     "noDefaultLabels": true,
     "labels": [
-      {
-        "name": "major",
-        "releaseType": "major",
-        "changelogTitle": "💥 Major changes",
-        "description": "Increment the major version when merged",
-        "color": "#C5000B"
-      },
-      {
-        "name": "minor",
-        "releaseType": "minor",
-        "changelogTitle": "🎁 Features",
-        "description": "Increment the minor version when merged",
-        "color": "#F1A60E"
-      },
-      {
-        "name": "patch",
-        "releaseType": "patch",
-        "changelogTitle": "🐞 Fixes",
-        "description": "Increment the patch version when merged",
-        "color": "#870048"
-      },
-      {
-        "name": "internal",
-        "changelogTitle": "🏠 Internal",
-        "description": "Changes only affect the internal API",
-        "releaseType": "none",
-        "color": "#696969",
-        "default": true
-      }
+        {
+            "name": "major",
+            "releaseType": "major",
+            "changelogTitle": "💥 Major changes",
+            "description": "Increment the major version when merged",
+            "color": "#C5000B"
+        },
+        {
+            "name": "minor",
+            "releaseType": "minor",
+            "changelogTitle": "🎁 Features",
+            "description": "Increment the minor version when merged",
+            "color": "#F1A60E"
+        },
+        {
+            "name": "patch",
+            "releaseType": "patch",
+            "changelogTitle": "🐞 Fixes",
+            "description": "Increment the patch version when merged",
+            "color": "#870048"
+        },
+        {
+            "name": "internal",
+            "changelogTitle": "🏠 Internal",
+            "description": "Changes only affect the internal API",
+            "releaseType": "none",
+            "color": "#696969",
+            "default": true
+        }
     ]
-  }
+}

--- a/.autorc.json
+++ b/.autorc.json
@@ -1,0 +1,38 @@
+{
+    "owner": "pleo-oss",
+    "repo": "s3-cache-action",
+    "author": "github.actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>",
+    "onlyPublishWithReleaseLabel": false,
+    "noDefaultLabels": true,
+    "labels": [
+      {
+        "name": "major",
+        "releaseType": "major",
+        "changelogTitle": "💥 Major changes",
+        "description": "Increment the major version when merged",
+        "color": "#C5000B"
+      },
+      {
+        "name": "minor",
+        "releaseType": "minor",
+        "changelogTitle": "🎁 Features",
+        "description": "Increment the minor version when merged",
+        "color": "#F1A60E"
+      },
+      {
+        "name": "patch",
+        "releaseType": "patch",
+        "changelogTitle": "🐞 Fixes",
+        "description": "Increment the patch version when merged",
+        "color": "#870048"
+      },
+      {
+        "name": "internal",
+        "changelogTitle": "🏠 Internal",
+        "description": "Changes only affect the internal API",
+        "releaseType": "none",
+        "color": "#696969",
+        "default": true
+      }
+    ]
+  }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,47 +1,54 @@
 name: Pull Request Check
 on:
-    pull_request:
-        types:
-            - opened
-            - edited
-            - reopened
-            - synchronize
+  pull_request:
+      types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
 
 concurrency:
-    group: actions-ci-${{ github.ref }}
-    cancel-in-progress: true
+  group: actions-ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-    semantic-title:
-        name: Check PR Title for Semantic Release Type
-        runs-on: ubuntu-22.04
-        permissions:
-            pull-requests: read
-        steps:
-            - name: Check PR Title
-              uses: amannn/action-semantic-pull-request@v3.4.2
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              with:
-                  validateSingleCommit: true
-    test:
-        name: Check
-        runs-on: ubuntu-22.04
-        permissions:
-            contents: read
-        steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-node@v2
-              with:
-                  node-version: '16.x'
-                  registry-url: 'https://registry.npmjs.org'
-                  cache: 'yarn'
+  release-title:
+    name: Check PR labels for release Type
+    runs-on: ubuntu-22.04
 
-            - run: yarn --frozen-lockfile
-            - run: make test
-            - run: make build
-            - run: make lint
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      
+      - name: Verify PR labels
+        uses: docker://agilepathway/pull-request-label-checker:latest
+        with:
+          one_of: major,minor,patch,internal
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
 
-            - name: Check if built version was committed
-              run: |
-                  git diff --exit-code || (echo "::error::You forgot to commit the built actions, run 'make' locally" && exit 1)
+  test:
+    name: Check
+    runs-on: ubuntu-22.04
+
+    permissions:
+        contents: read
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v2
+        with:
+            node-version: '16.x'
+            registry-url: 'https://registry.npmjs.org'
+            cache: 'yarn'
+
+      - run: yarn --frozen-lockfile
+      - run: make test
+      - run: make build
+      - run: make lint
+
+      - name: Check if built version was committed
+        run: |
+            git diff --exit-code || (echo "::error::You forgot to commit the built actions, run 'make' locally" && exit 1)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,54 +1,54 @@
 name: Pull Request Check
 on:
-  pull_request:
-      types:
-      - opened
-      - edited
-      - reopened
-      - synchronize
-      - labeled
-      - unlabeled
+    pull_request:
+        types:
+            - opened
+            - edited
+            - reopened
+            - synchronize
+            - labeled
+            - unlabeled
 
 concurrency:
-  group: actions-ci-${{ github.ref }}
-  cancel-in-progress: true
+    group: actions-ci-${{ github.ref }}
+    cancel-in-progress: true
 
 jobs:
-  release-title:
-    name: Check PR labels for release type
-    runs-on: ubuntu-22.04
+    release-title:
+        name: Check PR labels for release type
+        runs-on: ubuntu-22.04
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      
-      - name: Verify PR labels
-        uses: docker://agilepathway/pull-request-label-checker:latest
-        with:
-          one_of: major,minor,patch,internal
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0
 
-  test:
-    name: Check
-    runs-on: ubuntu-22.04
+            - name: Verify PR labels
+              uses: docker://agilepathway/pull-request-label-checker:latest
+              with:
+                  one_of: major,minor,patch,internal
+                  repo_token: ${{ secrets.GITHUB_TOKEN }}
 
-    permissions:
-        contents: read
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
-        with:
-            node-version: '16.x'
-            registry-url: 'https://registry.npmjs.org'
-            cache: 'yarn'
+    test:
+        name: Check
+        runs-on: ubuntu-22.04
 
-      - run: yarn --frozen-lockfile
-      - run: make test
-      - run: make build
-      - run: make lint
+        permissions:
+            contents: read
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-node@v2
+              with:
+                  node-version: '16.x'
+                  registry-url: 'https://registry.npmjs.org'
+                  cache: 'yarn'
 
-      - name: Check if built version was committed
-        run: |
-            git diff --exit-code || (echo "::error::You forgot to commit the built actions, run 'make' locally" && exit 1)
+            - run: yarn --frozen-lockfile
+            - run: make test
+            - run: make build
+            - run: make lint
+
+            - name: Check if built version was committed
+              run: |
+                  git diff --exit-code || (echo "::error::You forgot to commit the built actions, run 'make' locally" && exit 1)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   release-title:
-    name: Check PR labels for release Type
+    name: Check PR labels for release type
     runs-on: ubuntu-22.04
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ concurrency:
 
 jobs:
     release-title:
+        permissions:
+            contents: write
+
         name: Check PR labels for release type
         runs-on: ubuntu-22.04
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
                   npx auto create-labels
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Verify PR labels
               uses: docker://agilepathway/pull-request-label-checker:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,7 @@ concurrency:
 
 jobs:
     release-title:
-        permissions:
-            contents: write
+        permissions: write-all
 
         name: Check PR labels for release type
         runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,12 @@ jobs:
               with:
                   fetch-depth: 0
 
+            - name: Ensure release labels
+              run: |
+                  npx auto create-labels
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
             - name: Verify PR labels
               uses: docker://agilepathway/pull-request-label-checker:latest
               with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,24 +15,10 @@ concurrency:
 
 jobs:
     release-title:
-        permissions: write-all
-
         name: Check PR labels for release type
         runs-on: ubuntu-22.04
 
         steps:
-            - name: Checkout code
-              uses: actions/checkout@v3
-              with:
-                  fetch-depth: 0
-
-            - name: Ensure release labels
-              run: |
-                  npx auto create-labels
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
             - name: Verify PR labels
               uses: docker://agilepathway/pull-request-label-checker:latest
               with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,25 +1,25 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - main
+    push:
+        branches:
+            - main
 
 jobs:
-  release:
-    name: Release changes
-    runs-on: ubuntu-22.04
-    permissions: 
-      packages: write
-      contents: write
-      pull-requests: write
+    release:
+        name: Release changes
+        runs-on: ubuntu-22.04
+        permissions:
+            packages: write
+            contents: write
+            pull-requests: write
 
-    steps: 
-    - name: Run Auto release
-      run: |
-        npx auto init
-        npx auto create-labels
-        npx auto shipit
-      env: 
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        steps:
+            - name: Run Auto release
+              run: |
+                  npx auto init
+                  npx auto create-labels
+                  npx auto shipit
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,6 @@ jobs:
         steps:
             - name: Run Auto release
               run: |
-                  npx auto init
                   npx auto shipit
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,4 +21,5 @@ jobs:
                   npx auto shipit
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,25 @@
 name: Release
 
 on:
-    push:
-        branches:
-            - main
+  push:
+    branches:
+      - main
 
 jobs:
-    release:
-        name: Run "Release Please"
-        runs-on: ubuntu-22.04
-        outputs:
-            release_created: ${{ steps.release.outputs.release_created }}
-        steps:
-            - uses: google-github-actions/release-please-action@v3
-              id: release
-              with:
-                  release-type: node
-                  package-name: '@pleo-oss/s3-cache-action'
+  release:
+    name: Release changes
+    runs-on: ubuntu-22.04
+    permissions: 
+      packages: write
+      contents: write
+      pull-requests: write
+
+    steps: 
+    - name: Run Auto release
+      run: |
+        npx auto init
+        npx auto create-labels
+        npx auto shipit
+      env: 
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,6 @@ jobs:
             - name: Run Auto release
               run: |
                   npx auto init
-                  npx auto create-labels
                   npx auto shipit
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This will use [Auto](https://intuit.github.io/auto/docs) for releasing the repository. This will make releasing the repository less prone to human error by avoiding relying on naming commits and their contents according to the `semantic-release` format. 

This will change the release workflow to use PR labels for releases, where a PR is labelled as either `major`, `minor`, `patch` or `internal` (for no release). These labels are verified in PRs and the library will be released, CHANGELOG generated and version bumped similarly to the current release flow.
